### PR TITLE
refactor: 统一摘要截取长度

### DIFF
--- a/admin/src/views/article/ArticleForm.vue
+++ b/admin/src/views/article/ArticleForm.vue
@@ -109,7 +109,7 @@
           <el-input
             v-model="formData.summary"
             type="textarea"
-            placeholder="请输入文章摘要，如不填写将自动截取内容前200字符"
+            placeholder="请输入文章摘要，如不填写将自动截取内容前150字符"
             :rows="3"
             maxlength="150"
             show-word-limit
@@ -635,7 +635,7 @@ const handleSave = async (autoRedirect: boolean = true) => {
         .replace(/[#*`>\-[\]]/g, '')
         .replace(/\s+/g, ' ')
         .trim()
-        .slice(0, 200);
+        .slice(0, 150);
     }
 
     // 提交数据

--- a/server/internal/service/article.go
+++ b/server/internal/service/article.go
@@ -1232,7 +1232,7 @@ func parseHexoArticle(content string) (*ParsedArticle, error) {
 	}
 
 	if parsed.Summary == "" {
-		parsed.Summary = generateSummary(parsed.Content, 200)
+		parsed.Summary = generateSummary(parsed.Content, 150)
 	}
 
 	return parsed, nil
@@ -1259,7 +1259,7 @@ func parseMarkdownArticle(filename, content string) (*ParsedArticle, error) {
 		parsed.Title = "未命名文章"
 	}
 
-	parsed.Summary = generateSummary(content, 200)
+	parsed.Summary = generateSummary(content, 150)
 	parsed.Content = content
 
 	return parsed, nil

--- a/server/pkg/ai/functions.go
+++ b/server/pkg/ai/functions.go
@@ -137,22 +137,18 @@ func (c *OpenAIClient) Test() error {
 
 // GenerateSummary 生成文章摘要（50-100字，创作者角度）
 func (c *OpenAIClient) GenerateSummary(content string) (string, error) {
-	content = truncateContent(content, 10000)
 	prompt := resolvePrompt(c.SummaryPrompt, defaultSummaryPrompt) + "\n\n文章内容：\n" + content
 	return c.callOpenAI(prompt)
 }
 
 // GenerateAISummary 生成AI摘要（150-200字，旁观者角度）
 func (c *OpenAIClient) GenerateAISummary(content string) (string, error) {
-	content = truncateContent(content, 10000)
 	prompt := resolvePrompt(c.AISummaryPrompt, defaultAISummaryPrompt) + "\n\n文章内容：\n" + content
 	return c.callOpenAI(prompt)
 }
 
 // GenerateTitle 生成标题
 func (c *OpenAIClient) GenerateTitle(content string) ([]string, error) {
-	content = truncateContent(content, 3000)
-
 	for i := 0; i < 3; i++ { // 最多重试3次
 		prompt := resolvePrompt(c.TitlePrompt, defaultTitlePrompt) + "\n\n文章核心内容：\n" + content + "\n\n标题："
 		result, err := c.callOpenAI(prompt)

--- a/server/pkg/utils/excerpt.go
+++ b/server/pkg/utils/excerpt.go
@@ -9,7 +9,7 @@ import (
 // GenerateExcerpt 生成包含关键词的文章摘录
 func GenerateExcerpt(content, keyword string, maxLength int) string {
 	if maxLength == 0 {
-		maxLength = 200
+		maxLength = 150
 	}
 
 	// 移除 Markdown 标记


### PR DESCRIPTION
## 变更描述

将文章摘要的默认截取长度从200字符调整为150字符，保持前后端及AI生成摘要的一致性

## 关联 Issue

无
